### PR TITLE
Update meta.yaml: bump version to 0.42.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "shap" %}
-{% set version = "0.41.0" %}
+{% set version = "0.42.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/slundberg/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: ce5117e7921f47128b529cffa0a5e7ad3f0ebcdc6d0ae57e929385bf49fb68f6
+  sha256: 73a9e99dee19e1db4ba058c5bf6209ce2bd49f6e91c3c16e94480f8bbb92c97a
 
 build:
   number: 2
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - packaging
-    - numpy <1.24.0  # see issue https://github.com/slundberg/shap/issues/2911
+    - numpy
     - scipy
     - scikit-learn
     - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - packaging
     - numpy
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 73a9e99dee19e1db4ba058c5bf6209ce2bd49f6e91c3c16e94480f8bbb92c97a
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

## Overview

Increments the version number to  `0.42.0` and updates the source hash.

Also removes the numpy pin (from #56), as `shap` has been tested against numpy `1.24`. 

## Context

The conda forge [update bot](https://conda-forge.org/status/#current_migrations) is currently failing:

```
3.00 attempts - The recipe did not change in the version migration, a URL did not hash, or there is jinja2 syntax the bot cannot handle!

Please check the URLs in your recipe with version '0.42.0' to make sure they exist!

We also found the following errors:

 - could not hash URL template 'https://github.com/slundberg/{{ name }}/archive/v{{ version }}.tar.gz'
 ```

This could be because the latest GitHub release of `shap` was deleted and re-released, due to an unusual anomaly.

For context - a new version of tensorflow was released at almost the exact same time that we made a GitHub release of shap `0.42.0` on GitHub. This moved us on to numpy 1.24, broke the tests .

The GH release triggers a pipeline to deploy to PyPI, a final run of the tests caught the new breaking change and the build failed. We deleted the GitHub release, fixed the numpy issue, and re-made the release (which is now up on PyPI and immutable).