### PR TITLE
Update numba version constraint in recipe.yaml

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -64,7 +64,6 @@ requirements:
     - if: osx and x86_64
       then:
         - llvmlite <0.46
-        - numba <0.65
     - cloudpickle
     - if: cuda_compiler_version != "None"
       then: __cuda

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -64,7 +64,7 @@ requirements:
     - if: osx and x86_64
       then:
         - llvmlite <0.46
-        - numba <0.63
+        - numba <0.65
     - cloudpickle
     - if: cuda_compiler_version != "None"
       then: __cuda


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The numba version 0.65 is available for osx on conda-forge. I think this boundary for numba on osx is actually not needed anymore.
[https://anaconda.org/channels/conda-forge/packages/numba/files?file_q=osx-64](https://anaconda.org/channels/conda-forge/packages/numba/files?file_q=osx-64)

